### PR TITLE
Update config.windows.v5.toml

### DIFF
--- a/config.windows.v5.toml
+++ b/config.windows.v5.toml
@@ -13,7 +13,7 @@ auth_url = "https://api.yuzu-emu.org/jwt/installer/"
     aud = "installer"
 
 [[packages]]
-name = "yuzu Team"
+name = "yuzu Team EA"
 description = "Early Access (Paid)\nLatest, Fast Updates"
 icon = "thicc_logo_installer__ea_shadow.png"
 requires_authorization = true


### PR DESCRIPTION
Both the early-access and mainline versions of the yuzu package had the same name, making it impossible to download the mainline version (the installer would always try to download the early-access one). This just changed the name of one of them to fix that issue.

This should fix the issue without requiring a new release, since the installer just grabs the latest version of this file from the main branch.